### PR TITLE
Test override

### DIFF
--- a/slc6-cvmfs-condor/Dockerfile
+++ b/slc6-cvmfs-condor/Dockerfile
@@ -13,4 +13,4 @@ COPY files/condor-container-pilot /tmp/condor-container-pilot
 
 RUN mkdir -p /cvmfs/alice-ocdb.cern.ch && mkdir -p /cvmfs/alice.cern.ch
 RUN chmod +x /tmp/condor-container-pilot
-ENTRYPOINT [ "entrypoint.sh" ]
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/slc6-cvmfs-condor/Dockerfile
+++ b/slc6-cvmfs-condor/Dockerfile
@@ -13,3 +13,4 @@ COPY files/condor-container-pilot /tmp/condor-container-pilot
 
 RUN mkdir -p /cvmfs/alice-ocdb.cern.ch && mkdir -p /cvmfs/alice.cern.ch
 RUN chmod +x /tmp/condor-container-pilot
+ENTRYPOINT [ "entrypoint.sh" ]


### PR DESCRIPTION
@dberzano 
The container image `plancton/slc6-fuse-ab:latest` i developed for the volunteer version of Plancton is based on the `alisw/slc6-cvmfs` one. I found that __with no apparent reasons__ starting this image, _using docker-py_ API handlers, fails because it literally can't find the `entrypoint.sh` file.
It obviously sounds weird since the mere 

`docker run --rm -i plancton/slc6-fuse-ab:latest /tmp/condor-container-pilot` 

runs smoothly.
I guess is something related to the environment available inside my container, even I can't figure it out why the command line interactive mode is actually working.
To solve this I overrode the `ENTRYPOINT` directive in my Dockerfile, specifying the absolute path to the `entrypoint.sh` file.
Obviously this can be better "chiselled" and it will, at the moment I'm auto-accepting this pr, making you apart if this issue.
